### PR TITLE
fix: Add poetry as a build dependency

### DIFF
--- a/packages/lang/python/python-atpython/Makefile
+++ b/packages/lang/python/python-atpython/Makefile
@@ -17,6 +17,8 @@ PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Chris Swan <@cpswan>
 
+PKG_BUILD_DEPENDS:=python-poetry-core/host
+
 include $(INCLUDE_DIR)/package.mk
 include $(TOPDIR)/feeds/packages/lang/python/python3-package.mk
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added `PKG_BUILD_DEPENDS:=python-poetry-core/host` to Makefile per [python-rsa](https://github.com/openwrt/packages/blob/master/lang/python/python-rsa/Makefile)

**- How I did it**

[Repo search](https://github.com/search?q=repo%3Aopenwrt%2Fpackages%20poetry&type=code) of openwrt/packages to find other packages using poetry

**- How to verify it**

Build will complete without manual install of poetry.

**- Description for the changelog**

fix: Add poetry as a build dependency