### PR TITLE
docs: Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ easy to run our stuff there.
 
 ### lang/python/atpython
 
-This package ontains our
+This package contains our
 [Python SDK](https://github.com/atsign-foundation/at_python)
 
 ## Development Environment Setup


### PR DESCRIPTION
Spotted a typo

**- What I did**

Added the missing `c`

**- Description for the changelog**

docs: Fix typo