### PR TITLE
chore: Use PyPI for packages rather than GitHub source

### DIFF
--- a/packages/lang/python/python-atsdk/Makefile
+++ b/packages/lang/python/python-atsdk/Makefile
@@ -5,17 +5,12 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=sshnpdpy
-PKG_VERSION:=0.3.0
+PKG_NAME:=atsdk
+PKG_VERSION:=0.2.0
 PKG_RELEASE:=1
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/atsign-foundation/sshnoports
-PKG_SOURCE_VERSION:=074699a29e31688dcba8b79fd55433e25c68355e
-
-PKG_BUILD_DEPENDS:=python-poetry-core/host
-
-PYTHON3_PKG_SETUP_DIR=packages/sshnpdpy
+PYPI_NAME:=atsdk
+PKG_HASH:=52f4b56597bdc25725b6e1cf9842800b4194def8b2691d0e9c0bb393f97a486e
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -24,7 +19,7 @@ PKG_MAINTAINER:=Chris Swan <@cpswan>
 include $(INCLUDE_DIR)/package.mk
 include $(TOPDIR)/feeds/packages/lang/python/python3-package.mk
 
-define Package/python3-sshnpdpy
+define Package/python3-atpython
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
@@ -32,19 +27,19 @@ define Package/python3-sshnpdpy
   URL:=https://github.com/atsign-foundation/at_python
   DEPENDS:=\
       +python3-light \
-      +python3-atpython \
-      +python3-bcrypt \
       +python3-cffi \
       +python3-cryptography \
-      +python3-paramiko \
+      +python3-dateutil \
       +python3-pycparser \
-      +python3-pynacl
+      +python3-pytest \
+      +python3-requests \
+      +python3-six
 endef
 
-define Package/python3-sshnpdpy/description
-Atsign SSH No Ports daemon in Python
+define Package/python3-atpython/description
+The atPlatform for Python developers
 endef
 
-$(eval $(call Py3Package,python3-sshnpdpy))
-$(eval $(call BuildPackage,python3-sshnpdpy))
-$(eval $(call BuildPackage,python3-sshnpdpy-src))
+$(eval $(call Py3Package,python3-atpython))
+$(eval $(call BuildPackage,python3-atpython))
+$(eval $(call BuildPackage,python3-atpython-src))

--- a/packages/lang/python/python-atsdk/Makefile
+++ b/packages/lang/python/python-atsdk/Makefile
@@ -16,6 +16,7 @@ PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Chris Swan <@cpswan>
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include $(TOPDIR)/feeds/packages/lang/python/python3-package.mk
 

--- a/packages/lang/python/python-atsdk/Makefile
+++ b/packages/lang/python/python-atsdk/Makefile
@@ -16,7 +16,7 @@ PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Chris Swan <@cpswan>
 
-include ../pypi.mk
+include $(TOPDIR)/feeds/packages/lang/python/pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include $(TOPDIR)/feeds/packages/lang/python/python3-package.mk
 

--- a/packages/lang/python/python-atsdk/Makefile
+++ b/packages/lang/python/python-atsdk/Makefile
@@ -19,7 +19,7 @@ PKG_MAINTAINER:=Chris Swan <@cpswan>
 include $(INCLUDE_DIR)/package.mk
 include $(TOPDIR)/feeds/packages/lang/python/python3-package.mk
 
-define Package/python3-atpython
+define Package/python3-atsdk
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
@@ -36,10 +36,10 @@ define Package/python3-atpython
       +python3-six
 endef
 
-define Package/python3-atpython/description
+define Package/python3-atsdk/description
 The atPlatform for Python developers
 endef
 
-$(eval $(call Py3Package,python3-atpython))
-$(eval $(call BuildPackage,python3-atpython))
-$(eval $(call BuildPackage,python3-atpython-src))
+$(eval $(call Py3Package,python3-atsdk))
+$(eval $(call BuildPackage,python3-atsdk))
+$(eval $(call BuildPackage,python3-atsdk-src))

--- a/packages/lang/python/python-sshnpd/Makefile
+++ b/packages/lang/python/python-sshnpd/Makefile
@@ -5,24 +5,21 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=at_python
-PKG_VERSION:=0.0.2
+PKG_NAME:=sshnpd
+PKG_VERSION:=0.4.1
 PKG_RELEASE:=1
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/atsign-foundation/at_python
-PKG_SOURCE_VERSION:=4da03279fa174a1fa2ab59b3d6e4aeb2b4f8d978
+PYPI_NAME:=sshnpd
+PKG_HASH:=3bb3bd1f00409598b2b7e8c70eb3acdb81c614224f64671d47b2c53a19dab1a4
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Chris Swan <@cpswan>
 
-PKG_BUILD_DEPENDS:=python-poetry-core/host
-
 include $(INCLUDE_DIR)/package.mk
 include $(TOPDIR)/feeds/packages/lang/python/python3-package.mk
 
-define Package/python3-atpython
+define Package/python3-sshnpdpy
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
@@ -30,19 +27,19 @@ define Package/python3-atpython
   URL:=https://github.com/atsign-foundation/at_python
   DEPENDS:=\
       +python3-light \
+      +python3-atpython \
+      +python3-bcrypt \
       +python3-cffi \
       +python3-cryptography \
-      +python3-dateutil \
+      +python3-paramiko \
       +python3-pycparser \
-      +python3-pytest \
-      +python3-requests \
-      +python3-six
+      +python3-pynacl
 endef
 
-define Package/python3-atpython/description
-The atPlatform for Python developers
+define Package/python3-sshnpdpy/description
+Atsign SSH No Ports daemon in Python
 endef
 
-$(eval $(call Py3Package,python3-atpython))
-$(eval $(call BuildPackage,python3-atpython))
-$(eval $(call BuildPackage,python3-atpython-src))
+$(eval $(call Py3Package,python3-sshnpdpy))
+$(eval $(call BuildPackage,python3-sshnpdpy))
+$(eval $(call BuildPackage,python3-sshnpdpy-src))

--- a/packages/lang/python/python-sshnpd/Makefile
+++ b/packages/lang/python/python-sshnpd/Makefile
@@ -16,6 +16,7 @@ PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Chris Swan <@cpswan>
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include $(TOPDIR)/feeds/packages/lang/python/python3-package.mk
 

--- a/packages/lang/python/python-sshnpd/Makefile
+++ b/packages/lang/python/python-sshnpd/Makefile
@@ -27,7 +27,7 @@ define Package/python3-sshnpd
   URL:=https://github.com/atsign-foundation/at_python
   DEPENDS:=\
       +python3-light \
-      +python3-atpython \
+      +python3-atsdk \
       +python3-bcrypt \
       +python3-cffi \
       +python3-cryptography \

--- a/packages/lang/python/python-sshnpd/Makefile
+++ b/packages/lang/python/python-sshnpd/Makefile
@@ -19,7 +19,7 @@ PKG_MAINTAINER:=Chris Swan <@cpswan>
 include $(INCLUDE_DIR)/package.mk
 include $(TOPDIR)/feeds/packages/lang/python/python3-package.mk
 
-define Package/python3-sshnpdpy
+define Package/python3-sshnpd
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
@@ -36,10 +36,10 @@ define Package/python3-sshnpdpy
       +python3-pynacl
 endef
 
-define Package/python3-sshnpdpy/description
+define Package/python3-sshnpd/description
 Atsign SSH No Ports daemon in Python
 endef
 
-$(eval $(call Py3Package,python3-sshnpdpy))
-$(eval $(call BuildPackage,python3-sshnpdpy))
-$(eval $(call BuildPackage,python3-sshnpdpy-src))
+$(eval $(call Py3Package,python3-sshnpd))
+$(eval $(call BuildPackage,python3-sshnpd))
+$(eval $(call BuildPackage,python3-sshnpd-src))

--- a/packages/lang/python/python-sshnpd/Makefile
+++ b/packages/lang/python/python-sshnpd/Makefile
@@ -16,7 +16,7 @@ PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Chris Swan <@cpswan>
 
-include ../pypi.mk
+include $(TOPDIR)/feeds/packages/lang/python/pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include $(TOPDIR)/feeds/packages/lang/python/python3-package.mk
 


### PR DESCRIPTION
Prior to publishing the Python SDK and sshnpd to PyPI we were building packages here from source.

**- What I did**

* Modified the Makefiles to use PyPI
* Adjusted the package names to align with PyPI

**- How to verify it**

* Build ipks for target platform (they're pure Python, so should work just about anywhere)
* Copy ipks to test instance 
* Install atsdk (NB will need plenty of storage for all the dependencies it pulls in. Should be fine on x86_64 VMs, but most real OpenWRT devices won't have enough flash)
* Install sshnpd
* Run sshnpd with chosen atsigns

**- Description for the changelog**

chore: Use PyPI for packages rather than GitHub source
