### PR TITLE
build(deps): Bump C sshnpd to 0.2.2

### DIFF
--- a/packages/csshnpd/Makefile
+++ b/packages/csshnpd/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=csshnpd
-PKG_VERSION:=0.2.1
+PKG_VERSION:=0.2.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-c$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/atsign-foundation/noports/releases/download/c$(PKG_VERSION)
-PKG_HASH:=d561b795ef3ab7411616e6fb57f969a7892b41b6cd8294a86d6fc5779461bba1
+PKG_HASH:=7865598bbd414c451f412be9d1cc233710a9d8d744479bcae8b84ae066fce1ef
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENCE


### PR DESCRIPTION
@XavierChanth identified another place where we needed to have more explicit casting of int types

**- What I did**

Bumped csshnpd to 0.2.2

**- How to verify it**

@XavierChanth to do manual testing on Opal once package built

**- Description for the changelog**

build(deps): Bump C sshnpd to 0.2.2
