### PR TITLE
fix: Prevent "someone does not honour COPTS correctly" warnings

### DIFF
--- a/packages/csshnpd/Makefile
+++ b/packages/csshnpd/Makefile
@@ -21,7 +21,7 @@ CMAKE_OPTIONS += \
 		-DBUILD_SHARED_LIBS=off \
 		-DBUILD_TESTS=off \
 		-DCMAKE_C_COMPILER=$(TARGET_CC) \
-		-DCMAKE_C_FLAGS="-Wno-calloc-transposed-args -Wno-error -pthread -lrt"
+		-DCMAKE_C_FLAGS="$(TARGET_CFLAGS) -Wno-calloc-transposed-args -Wno-error -pthread -lrt"
 
 define Package/csshnpd
 	SECTION:=net


### PR DESCRIPTION
Build logs have been littered with:

```
cc1: note: someone does not honour COPTS correctly, passed 0 times
```

**- What I did**

Added $(TARGET_CFLAGS) to DCMAKE_C_FLAGS

**- How I did it**

https://forum.archive.openwrt.org/viewtopic.php?id=25306 pointed the way

**- How to verify it**

Test builds are already completing without warnings

**- Description for the changelog**

fix: Prevent "someone does not honour COPTS correctly" warnings