### PR TITLE
build(deps): Bump C sshnpd to 0.2.3

### DIFF
--- a/packages/csshnpd/Makefile
+++ b/packages/csshnpd/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=csshnpd
-PKG_VERSION:=0.2.2
+PKG_VERSION:=0.2.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-c$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/atsign-foundation/noports/releases/download/c$(PKG_VERSION)
-PKG_HASH:=7865598bbd414c451f412be9d1cc233710a9d8d744479bcae8b84ae066fce1ef
+PKG_HASH:=a3243ce541ebfc60b23f80f633040921181b5b7dee0d70f582db691701df476d
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENCE


### PR DESCRIPTION
Uptake at_c 0.3.1 via C sshnpd 0.2.3 to deal with compiler warnings.

**- What I did**

Bumped C sshnpd to 0.2.3

**- How to verify it**

Build some packages and observe warnings

**- Description for the changelog**

build(deps): Bump C sshnpd to 0.2.3
