### PR TITLE
build(deps): Bump C sshnpd to 0.2.4

### DIFF
--- a/packages/csshnpd/Makefile
+++ b/packages/csshnpd/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=csshnpd
-PKG_VERSION:=0.2.3
+PKG_VERSION:=0.2.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-c$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/atsign-foundation/noports/releases/download/c$(PKG_VERSION)
-PKG_HASH:=a3243ce541ebfc60b23f80f633040921181b5b7dee0d70f582db691701df476d
+PKG_HASH:=76ff5b62549681162c1c9e0faaa8eefbc9e1fb252e292be012a34d390ad63311
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENCE


### PR DESCRIPTION
Incorporating various fixes that should deal with compiler warnings

**- What I did**

Bumped version and hash for c0.2.4 release

**- How to verify it**

Rebuild .ipks

**- Description for the changelog**

build(deps): Bump C sshnpd to 0.2.4
