### PR TITLE
feat: define conffiles

### DIFF
--- a/packages/csshnpd/Makefile
+++ b/packages/csshnpd/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=csshnpd
 PKG_VERSION:=0.2.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-c$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/atsign-foundation/noports/releases/download/c$(PKG_VERSION)
@@ -36,7 +36,7 @@ define Package/csshnpd/description
 endef
 
 define Package/csshnpd/conffiles
-	/etc/config/sshnpd
+/etc/config/sshnpd
 endef
 
 define Package/csshnpd/install	

--- a/packages/csshnpd/Makefile
+++ b/packages/csshnpd/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=csshnpd
 PKG_VERSION:=0.2.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-c$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/atsign-foundation/noports/releases/download/c$(PKG_VERSION)
@@ -33,6 +33,10 @@ endef
 
 define Package/csshnpd/description
 	A small and portable daemon for NoPorts.
+endef
+
+define Package/csshnpd/conffiles
+	/etc/config/sshnpd
 endef
 
 define Package/csshnpd/install	


### PR DESCRIPTION
When upgrading a package the config can be overwritten

**- What I did**

Added a conffiles definition

**- How to verify it**

Tested on my One:

```log
root@OpenWrt:~# opkg upgrade csshnpd csshnpd_0.2.4-r3_aarch64_cortex-a53.ipk
Upgrading csshnpd on root from 0.2.4-r2 to 0.2.4-r3...
Unknown package 'csshnpd_0.2.4-r3_aarch64_cortex-a53.ipk'.
Configuring csshnpd.
Collected errors:
 * resolve_conffiles: Existing conffile /etc/config/sshnpd is different from the conffile in the new package. The new conffile will be placed at /etc/config/sshnpd-opkg.
```

**- Description for the changelog**

feat: define conffiles
