### PR TITLE
fix: Use -fhonour-copts rather than $(TARGET_CFLAGS)

### DIFF
--- a/packages/csshnpd/Makefile
+++ b/packages/csshnpd/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=csshnpd
 PKG_VERSION:=0.2.4
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-c$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/atsign-foundation/noports/releases/download/c$(PKG_VERSION)
@@ -21,7 +21,7 @@ CMAKE_OPTIONS += \
 		-DBUILD_SHARED_LIBS=off \
 		-DBUILD_TESTS=off \
 		-DCMAKE_C_COMPILER=$(TARGET_CC) \
-		-DCMAKE_C_FLAGS="$(TARGET_CFLAGS) -Wno-calloc-transposed-args -Wno-error -pthread -lrt"
+		-DCMAKE_C_FLAGS="-fhonour-copts -Wno-calloc-transposed-args -Wno-error -pthread -lrt"
 
 define Package/csshnpd
 	SECTION:=net


### PR DESCRIPTION
Fixes #31 

**- What I did**

Replaced `$(TARGET_CFLAGS)` with `-fhonour-copts` to prevent compiler errors when building for ramips.

**- How I did it**

Discussion with arch group chose this as the pragmatic way ahead (rather than trying to figure out why `$(TARGET_CFLAGS)` for ramips is throwing in bad flags

**- How to verify it**

I've already done manual builds for a variety of targets and it'd produced good packages without warnings.

**- Description for the changelog**

fix: Use -fhonour-copts rather than $(TARGET_CFLAGS)