### PR TITLE
build(deps): Bump C sshnpd to c0.4.2

### DIFF
--- a/packages/csshnpd/Makefile
+++ b/packages/csshnpd/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=csshnpd
-PKG_VERSION:=0.4.0
+PKG_VERSION:=0.4.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-c$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/atsign-foundation/noports/releases/download/c$(PKG_VERSION)
-PKG_HASH:=fcf03f8ed810c5e6acc98282e709197afef77e8dd998d5ad7ca34943ac484db0
+PKG_HASH:=8440d0e6edb9b90eff50a5cf507e60a274c553cc9a6a7ede93bba5deb0da4a46
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENCE


### PR DESCRIPTION
**- What I did**

Bumped C sshnpd to c0.4.2

**- How I did it**

Updated PKG_VERSION and PKG_HASH from

**- How to verify it**

I'll do builds and create a release

**- Description for the changelog**

build(deps): Bump C sshnpd to c0.4.2
