### PR TITLE
build(deps): Bump C sshnpd to c1.0.0

### DIFF
--- a/packages/csshnpd/Makefile
+++ b/packages/csshnpd/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=csshnpd
-PKG_VERSION:=0.4.3
+PKG_VERSION:=1.0.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-c$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/atsign-foundation/noports/releases/download/c$(PKG_VERSION)
-PKG_HASH:=3b0d16a8dfc5648cf5e7d5fea86a6e69dcc04f404628e72e7b447c746d08b866
+PKG_HASH:=e71ee216f989cd9cbc047f1c2e301122d41e6e08c9886156a8e286c7cef05da3
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENCE


### PR DESCRIPTION
**- What I did**

Bumped version to c1.0.0

**- How I did it**

Took SHA from checksums.txt in c1.0.0 release

**- How to verify it**

I'll build the usual packages

**- Description for the changelog**

build(deps): Bump C sshnpd to c1.0.0