### PR TITLE
feat: Add OTP to config template

### DIFF
--- a/packages/csshnpd/files/csshnpd.config
+++ b/packages/csshnpd/files/csshnpd.config
@@ -3,4 +3,5 @@ config sshnpd
 	option manager  '@manager'
 	option device   'devicename'
 	option args     ''
+	option otp      ''
 	option enabled	'0'


### PR DESCRIPTION
Config template was missing otp section. This wasn't a problem with configuring via the LuCI app, but should be there to help with CLI based config.

**- What I did**

Added otp section

**- Description for the changelog**

feat: Add OTP to config template