### PR TITLE
build(deps): Bump C sshnpd to c1.0.7

### DIFF
--- a/packages/csshnpd/Makefile
+++ b/packages/csshnpd/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=csshnpd
-PKG_VERSION:=1.0.6
+PKG_VERSION:=1.0.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-c$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/atsign-foundation/noports/releases/download/c$(PKG_VERSION)
-PKG_HASH:=ebb6e9299977fe4a24b56a1dd099996afd42002eca0e7ba5819eb0bfd3e400de
+PKG_HASH:=0f7c8809985688aa80cf10e0c13dd1f40e8fe809925d201641132f865bc38ccc
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENCE

--- a/packages/csshnpd/Makefile
+++ b/packages/csshnpd/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=csshnpd
-PKG_VERSION:=1.0.4
+PKG_VERSION:=1.0.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-c$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/atsign-foundation/noports/releases/download/c$(PKG_VERSION)
-PKG_HASH:=09fed244bbf8d5bc1a51c3a2d061deebe96345a4c4d0b01cc3446827c4df98a1
+PKG_HASH:=ebb6e9299977fe4a24b56a1dd099996afd42002eca0e7ba5819eb0bfd3e400de
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENCE
@@ -24,7 +24,7 @@ CMAKE_OPTIONS += \
 	-DNOPORTS_ATSDK_PATH="deps/atsdk-src"\
 	-DBUILD_SHARED_LIBS="OFF" \
 	-DCMAKE_BUILD_TYPE="Release" \
-	-DCMAKE_C_FLAGS="-std=c99 -Wno-error -Wextra -Werror-implicit-function-declaration -fPIC -fhonour-copts -Wno-calloc-transposed-args" \
+	-DCMAKE_C_FLAGS="-std=c99 -Wno-error -Wextra -Werror-implicit-function-declaration -fPIC -fhonour-copts" \
 	-DCMAKE_INSTALL_PREFIX="${PKG_BUILD_DIR}/build/release-static/tmp-install-dir" \
 	-DCMAKE_EXPORT_COMPILE_COMMANDS="OFF" \
 	-DATSDK_BUILD_TESTS="OFF" \


### PR DESCRIPTION
Builds on OpenWrt SDKs without warnings to progress #40 

**- What I did**

* Updated version and hash for c1.0.7 release
* Removed `-Wno-calloc-transposed-args` flag

**- How I did it**

Builds tested against the usual SDK selection

**- How to verify it**

Install packages on OpenWrt VMs and routers

**- Description for the changelog**

build(deps): Bump C sshnpd to c1.0.7
