### PR TITLE
docs: Update README - naming and repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,47 @@
 <a href="https://atsign.com#gh-light-mode-only"><img width=250px src="https://atsign.com/wp-content/uploads/2022/05/atsign-logo-horizontal-color2022.svg#gh-light-mode-only" alt="The Atsign Foundation"></a><a href="https://atsign.com#gh-dark-mode-only"><img width=250px src="https://atsign.com/wp-content/uploads/2023/08/atsign-logo-horizontal-reverse2022-Color.svg#gh-dark-mode-only" alt="The Atsign Foundation"></a>
 
-# Atsign OpenWRT packages
+# Atsign OpenWrt packages
 
 This repo contains the source code to build packages for
-[OpenWRT](https://openwrt.org/), a Linux operating system targeting embedded
+[OpenWrt](https://openwrt.org/), a Linux operating system targeting embedded
 devices.
 
-OpenWRT is very popular with device manufacturers, and we want to make it
+OpenWrt is very popular with device manufacturers, and we want to make it
 easy to run our stuff there.
 
 ## Packages
+
+### Upstream support in SNAPSHOT
+
+[csshnpd](https://github.com/openwrt/packages/tree/master/net/csshnpd)
+has been accepted upstream in
+[openwrt/packages](https://github.com/openwrt/packages), and
+[luci-app-csshnpd](https://github.com/openwrt/luci/tree/master/applications/luci-app-csshnpd)
+is in [openwrt/luci](https://github.com/openwrt/luci). So if you're running
+a SNAPSHOT build, NoPorts can be installed with:
+
+```sh
+apk update
+apk add luci-app-csshnpd
+```
+
+or if you just want the command line app:
+
+```sh
+apk update
+apk add csshnpd
+```
+
+### Package repo for OpenWrt 23.05 and 24.10
+
+An automated build based on this repo -
+[OpenWrt-publishing](https://github.com/atsign-foundation/OpenWrt-publishing/)
+creates the
+[Atsign opkg repository](https://atsign-foundation.github.io/OpenWrt-releases/)
+
+Follow the
+[install guide](https://github.com/atsign-foundation/OpenWrt-releases/tree/gh-pages#readme)
+for instructions on adding the repo key and packages from it.
 
 ### csshnpd
 
@@ -32,15 +64,17 @@ NB that command line will vary according to version and platform architecture.
 The config is held in `/etc/config/sshnpd`
 
 Use your favourite editor to set `atsign`, `manager` and `device` to the
-atSigns and name you wish to use.
+atSigns and name you wish to use, and `otp` to the One Time Password (OTP)
+or Semi-Permanent Password (SPP) to be used for enrollment.
 
 `enabled` needs to be changed to `1`
 
 #### Getting atSign keys in place
 
-sshnpd expect to find keys in `$HOME/.atsign/keys`. For now keys need to be
-activated elsewhere and copied into an `@atsign__key.atKeys` file (where
-`atsign` is replaced with the atSign being used for the device).
+sshnpd expect to find keys in `$HOME/.atsign/keys`.
+
+Once the config has been customised an atKeys file can be generated using
+the `at_enroll.sh` script.
 
 #### Starting the daemon
 
@@ -82,21 +116,21 @@ press the `Start` button beside `sshnpd`.
 
 ## Development Environment Setup
 
-Please start by setting up an OpenWRT toolchain following the steps in their
+Please start by setting up an OpenWrt toolchain following the steps in their
 [Developer guide](https://openwrt.org/docs/guide-developer/start)
 
 If you've got past
-["Hello World!" for OpenWRT](https://openwrt.org/docs/guide-developer/helloworld/start)
+["Hello World!" for OpenWrt](https://openwrt.org/docs/guide-developer/helloworld/start)
 then you're ready to use this.
 
 ### Using this repo as a feed
 
 First clone this repo from GitHub.
 
-Then create a `feeds.conf` in the root of the OpenWRT build tree e.g.:
+Then create a `feeds.conf` in the root of the OpenWrt build tree e.g.:
 
 ```
-src-link atsign /home/chris/git/github.com/atsign-foundation/Atsign_OpenWRT_packages/packages
+src-link atsign /home/chris/git/github.com/atsign-foundation/Atsign_OpenWrt_packages/packages
 ```
 
 You'll need to change `/home/chris/git/github.com/atsign-foundation/`


### PR DESCRIPTION
We had incorrect capitalisation of OpenWrt

**- What I did**

* Fixed caps
* Added details of upstream and the stable package repos

**- How to verify it**

Rich diff

**- Description for the changelog**

docs: Update README - naming and repos
