### PR TITLE
build(deps): Bump csshnpd to c1.0.16

### DIFF
--- a/packages/csshnpd/Makefile
+++ b/packages/csshnpd/Makefile
@@ -4,12 +4,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=csshnpd
-PKG_VERSION:=1.0.14
+PKG_VERSION:=1.0.16
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-c$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/atsign-foundation/noports/releases/download/c$(PKG_VERSION)
-PKG_HASH:=86c9f3e5d3b149df9a32ef7b3ae52e78623c1beed4bedcfe90c852ea8504b40f
+PKG_HASH:=209501b5623cbb25e22b5f39eeedcb79c2b658a250ff31dd88b27b31677b6763
 
 PKG_MAINTAINER:=Chris Swan <chris@atsign.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
**- What I did**

Bumped version and hash to matched c1.0.16 release of C sshnpd

**- Description for the changelog**

build(deps): Bump C sshnpd to c1.0.16