### PR TITLE
build(deps): Bump C sshnpd to c1.0.19

### DIFF
--- a/packages/csshnpd/Makefile
+++ b/packages/csshnpd/Makefile
@@ -4,12 +4,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=csshnpd
-PKG_VERSION:=1.0.18
+PKG_VERSION:=1.0.19
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-c$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/atsign-foundation/noports/releases/download/c$(PKG_VERSION)
-PKG_HASH:=9792b6efc880922d6e0020ae751789c6350e72c339fde9928b2db918adf2a559
+PKG_HASH:=aa25fe0e59d467362e4a0fa5f2ae3995ef16123b4ca3e077df7cf16d99c481aa
 
 PKG_MAINTAINER:=Chris Swan <chris@atsign.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
**- What I did**

Bumped version and hash to matched c1.0.19 release of C sshnpd

**- Description for the changelog**

build(deps): Bump C sshnpd to c1.0.19